### PR TITLE
Bump bootstrap from 3.0.0 to 3.4.1 in /David.BooksStore.WebApp

### DIFF
--- a/David.BooksStore.WebApp/packages.config
+++ b/David.BooksStore.WebApp/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="4.8.1" targetFramework="net45" />
   <package id="Autofac.Mvc5" version="4.0.2" targetFramework="net45" />
-  <package id="bootstrap" version="3.0.0" targetFramework="net45" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net45" />
   <package id="Castle.Core" version="4.3.1" targetFramework="net45" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />


### PR DESCRIPTION
Bumps bootstrap from 3.0.0 to 3.4.1.

Signed-off-by: dependabot[bot] <support@github.com>